### PR TITLE
Don't use `realpath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Add `zgen load chr-fritz/docker-completion.zshplugin` to your `.zshrc` with your
 1. Clone this repository, then add its bin directory to your `$PATH`.
 2. Add `source /path/to/here/docker-completion.zshplugin` to your `.zshrc` file.
 
+### Run once
+
+It's enough to run this plugin just once, assuming the plugin or Docker Desktop don't change the completion location.
+The site-functions directory might not be user-writable, so use elevated permissions.
+
+```shell
+git clone https://github.com/chr-fritz/docker-completion.zshplugin docker-completion
+cd docker-completion
+sudo zsh docker-completion.plugin.zsh
+```
+
 ## License
 
 Apache License 2.0 © 2020 Christian Fritz

--- a/docker-completion.plugin.zsh
+++ b/docker-completion.plugin.zsh
@@ -26,7 +26,8 @@ __dockerCompletion_linkIfNeeded() {
 # It assumes that the completions are relative to the real path of the docker command.
 # This is the normal case for all Docker for Mac installations.
 __dockerCompletion_basePath() {
-    dirname $(dirname $(realpath $(which docker)))
+    docker_loc=$(which docker)
+    dirname $(dirname ${docker_loc:A})
 }
 
 # Registers the docker completions from the Docker for Mac installation.
@@ -38,4 +39,3 @@ __dockerCompletion_registerCompletion(){
 }
 
 __dockerCompletion_registerCompletion
-


### PR DESCRIPTION
`Realpath` is not available on current MacOS by default, so replace it's use by zsh native variable substitution.

Closes #2