### PR TITLE
Replace `zgen` with `zgenom` in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ plugins=( ... docker-completion ...)
 ...
 ```
 
-### [Zgen](https://github.com/tarjoilija/zgen)
+### [Zgenom](https://github.com/jandamm/zgenom)
 
-Add `zgen load chr-fritz/docker-completion.zshplugin` to your `.zshrc` with your other load commands.
+Add `zgenom load chr-fritz/docker-completion.zshplugin` to your `.zshrc` with your other load commands.
 
 ### Without using any frameworks
 


### PR DESCRIPTION
`zgen` hasn't been updated in years, so replace it in the install instructions with `zgenom`, which is a fork of `zgen` that is being actively maintained.